### PR TITLE
Feat: Implement daily email submission limit

### DIFF
--- a/src/app/api/oracle/route.ts
+++ b/src/app/api/oracle/route.ts
@@ -24,55 +24,98 @@ async function getSheetsClient() {
     return google.sheets({ version: 'v4', auth });
 }
 
+interface UserSubmission {
+    rowIndex: number;
+    name: string;
+    lastSubmissionTimestamp: string;
+}
+
 /**
- * Checks if a user has already made a submission today using the Google Sheet.
+ * Finds a user's submission in the Google Sheet by email.
+ * @param email The email of the user to find.
+ * @returns {Promise<UserSubmission | null>} An object with rowIndex, name, and lastSubmissionTimestamp, or null if not found.
  */
-async function hasConsultedToday(email: string): Promise<boolean> {
+async function findUserSubmission(email: string): Promise<UserSubmission | null> {
     try {
         const sheets = await getSheetsClient();
         const response = await sheets.spreadsheets.values.get({
             spreadsheetId: SPREADSHEET_ID,
-            range: 'Sheet1!A:C', // Check columns for Email and Timestamp
+            range: 'Sheet1!A:C', // Read Email, Name, and Timestamp columns
         });
 
         const rows = response.data.values;
         if (rows && rows.length) {
-            const today = new Date().toDateString();
-            return rows.some(row => {
-                const rowEmail = row[0];
-                const rowTimestamp = row[2];
-                if (rowEmail === email && rowTimestamp) {
-                    const submissionDate = new Date(rowTimestamp).toDateString();
-                    return submissionDate === today;
+            for (let i = 0; i < rows.length; i++) {
+                const row = rows[i];
+                if (row[0] === email) {
+                    return {
+                        rowIndex: i,
+                        name: row[1] || "",
+                        lastSubmissionTimestamp: row[2] || "",
+                    };
                 }
-                return false;
-            });
+            }
         }
-        return false;
+        return null; // Email not found
     } catch (error) {
-        console.error("Error checking Google Sheet:", error);
-        // Fail open - allow consultation if sheet check fails
-        return false;
+        console.error("Error finding user submission in Google Sheet:", error);
+        throw new Error("Could not retrieve user data from Google Sheet due to a server error.");
     }
 }
 
 /**
- * Adds a new entry to the Google Sheet.
+ * Adds a new consultation to the Google Sheet or updates an existing one.
+ * If rowIndex is provided, it updates; otherwise, it appends.
  */
-async function recordConsultation(email: string, name: string, timestamp: string) {
+async function addOrUpdateConsultation(
+    email: string,
+    name: string,
+    timestamp: string,
+    rowIndex?: number
+): Promise<boolean> {
     try {
         const sheets = await getSheetsClient();
-        await sheets.spreadsheets.values.append({
-            spreadsheetId: SPREADSHEET_ID,
-            range: 'Sheet1!A:C',
-            valueInputOption: 'USER_ENTERED',
-            requestBody: {
-                values: [[email, name, timestamp]],
-            },
-        });
+        if (rowIndex !== undefined && rowIndex !== null) {
+            const range = `Sheet1!B${rowIndex + 1}:C${rowIndex + 1}`;
+            await sheets.spreadsheets.values.update({
+                spreadsheetId: SPREADSHEET_ID,
+                range: range,
+                valueInputOption: 'USER_ENTERED',
+                requestBody: {
+                    values: [[name, timestamp]], // Update name and timestamp
+                },
+            });
+            console.log(`Updated row ${rowIndex + 1} for email ${email}`);
+        } else {
+            await sheets.spreadsheets.values.append({
+                spreadsheetId: SPREADSHEET_ID,
+                range: 'Sheet1!A:C',
+                valueInputOption: 'USER_ENTERED',
+                requestBody: {
+                    values: [[email, name, timestamp]],
+                },
+            });
+            console.log(`Appended new row for email ${email}`);
+        }
+        return true;
     } catch (error) {
-        console.error("Error writing to Google Sheet:", error);
-        // Log the error but don't block the user's response
+        console.error("Error adding or updating Google Sheet:", error);
+        return false;
+    }
+}
+
+// Helper function to check if two dates are the same day
+function isSameDay(dateStr1: string, dateStr2: string): boolean {
+    if (!dateStr1 || !dateStr2) return false; // Handle empty or invalid timestamps
+    try {
+        const d1 = new Date(dateStr1);
+        const d2 = new Date(dateStr2);
+        return d1.getFullYear() === d2.getFullYear() &&
+               d1.getMonth() === d2.getMonth() &&
+               d1.getDate() === d2.getDate();
+    } catch (e) {
+        console.error("Error comparing dates:", e);
+        return false; // If timestamps are invalid, treat as not the same day to be safe or handle error appropriately
     }
 }
 
@@ -84,37 +127,61 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Question is required" }, { status: 400 });
     }
 
-    if (email) {
-      if (await hasConsultedToday(email)) {
-        return NextResponse.json({ error: "You have already consulted the oracle today. Please return tomorrow for new guidance." }, { status: 429 });
-      }
-    }
+    let sheetOperationSuccessful = false;
 
-    const selectedCard: OracleCard = card || drawRandomCard();
+    if (email) {
+        const existingSubmission = await findUserSubmission(email);
+
+        if (existingSubmission) {
+            // User found, check timestamp
+            if (isSameDay(existingSubmission.lastSubmissionTimestamp, timestamp)) {
+                // Submission from today already exists
+                return NextResponse.json({ error: "You have already consulted the oracle today. Please return tomorrow for new guidance." }, { status: 429 });
+            } else {
+                // Submission from a previous day, update it
+                sheetOperationSuccessful = await addOrUpdateConsultation(email, name, timestamp, existingSubmission.rowIndex);
+                if (!sheetOperationSuccessful) {
+                    console.error(`Failed to update consultation for existing user: ${email}`);
+                    return NextResponse.json({ error: "Your consultation was generated, but there was an issue updating your details. Please try again later." }, { status: 500 });
+                }
+            }
+        } else {
+            // New user, add them
+            sheetOperationSuccessful = await addOrUpdateConsultation(email, name, timestamp);
+            if (!sheetOperationSuccessful) {
+                console.error(`Failed to add consultation for new user: ${email}`);
+                return NextResponse.json({ error: "Your consultation was generated, but there was an issue saving your details. Please try again later." }, { status: 500 });
+            }
+        }
+    } else {
+        // No email provided, proceed without sheet operations but mark as "successful" for flow
+        sheetOperationSuccessful = true;
+    }
     
+    // Generate AI response - this happens regardless of email submission status,
+    // but email sending and sheet recording depend on `email` being present.
+    const selectedCard: OracleCard = card || drawRandomCard();
     const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
     const prompt = `You are KiaOra Oracle, an intuitive Maori healer specializing in spiritual guidance. User name: "${name || "Seeker"}" User intent/question: "${question}" Card Drawn: "${selectedCard.name}" - "${selectedCard.meaning}" Create a personalized, insightful, and supportive oracle reading integrating the user's intent and the meaning of the card, using a mystical yet reassuring tone aligned with holistic Māori healing practices. Keep your response concise (80-120 words), actionable, and warm.`;
 
     const result = await model.generateContent(prompt);
-    const response = await result.response;
-    const responseText = response.text() || "The oracle is silent at this moment. Please try again later.";
+    const responseText = (await result.response).text() || "The oracle is silent at this moment. Please try again later.";
 
-    // Record consultation and send email
-    if (email) {
-        // We use `await` here but don't let it block the response to the user.
-        // The recording and emailing can happen in the background.
-        recordConsultation(email, name, timestamp);
-        sendOracleConsultation(email, question, responseText, name);
+    // Send email only if email was provided and sheet operation was successful
+    if (email && sheetOperationSuccessful) {
+        sendOracleConsultation(email, question, responseText, name); // Async, don't need to await if not critical path
     }
     
     return NextResponse.json({
       response: responseText,
     });
 
-  } catch (error) {
+  } catch (error: any) { // Catch any error, including those from findUserSubmission
     console.error("Oracle API error:", error);
+    // Check if it's an error message we threw intentionally (e.g., from findUserSubmission)
+    const errorMessage = error.message || "Failed to consult the oracle due to an unexpected server error.";
     return NextResponse.json(
-      { error: "Failed to consult the oracle. " + (error as Error).message },
+      { error: errorMessage },
       { status: 500 }
     );
   }


### PR DESCRIPTION
- Users can now submit the form once per email address per day.
- If an email is submitted for the first time, a new row is added to the Google Sheet.
- If an existing email is submitted on a subsequent day, the timestamp and name for that email's row are updated.
- If an existing email is submitted on the same day, the submission is rejected with a 429 error.

Key changes:
- Added `findUserSubmission` to locate existing entries and their last submission time.
- Modified `addOrUpdateConsultation` to handle both appending new entries and updating existing ones (name and timestamp fields).
- Updated the main POST handler to orchestrate this logic, including date comparison using a new `isSameDay` helper function.
- Ensured robust error handling for Google Sheets operations.